### PR TITLE
[maint] More fixes for installation in CentOS 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext {
         env = System.getenv()
         buildNumber = env.BUILD_NUMBER ? env.BUILD_NUMBER.toString() : ((int) (System.currentTimeMillis() / 1000)).toString()
-        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL          : 'http://172.20.201.85:8081/artifactory'
+        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL          : 'http://artifactory.asm.delllabs.net:8080/artifactory'
         ASMNEXT_REPO = hasProperty('ASMNEXT_REPO') ? ASMNEXT_REPO             : 'asmnext-trunk-ci'
         ASMNEXT_REPO_URL = hasProperty('ASMNEXT_REPO_URL') ? ASMNEXT_REPO_URL : "${BASE_REPO_URL}/${ASMNEXT_REPO}"
         PLUGINS_REPO = hasProperty('PLUGINS_REPO') ? PLUGINS_REPO             : 'plugins-release'
@@ -21,7 +21,7 @@ buildscript {
         moduleFolder = env.MODULE_FOLDER ? env.MODULE_FOLDER : 'xinetd'
         gitFolder = env.GIT_FOLDER ? env.GIT_FOLDER : moduleName
         gitRepo = env.REPONAME ? env.REPONAME : gitFolder
-        moduleVersion = env.MODULE_VERSION ? env.MODULE_VERSION : '1.2.0'
+        moduleVersion = env.MODULE_VERSION ? env.MODULE_VERSION : '8.4.0'
 
         rpm_description = env.RPM_DESCRIPTION ? env.RPM_DESCRIPTION : 'Puppet module packaged for consumption by Dell ASM'
         rpm_summary     = env.RPM_SUMMARY     ? env.RPM_SUMMARY     : 'Puppet module packaged for consumption by Dell Active Systems Manager.'
@@ -38,7 +38,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.redline-rpm:redline:1.2.4'
+        classpath 'org.redline-rpm:redline:1.2.6'
     }
 }
 
@@ -153,16 +153,16 @@ def buildModuleRpm(moduleName,moduleVersion,puppetModulesFolder='/etc/puppetlabs
         } else if (element.isDirectory()) {
             rpmBuilder.addDirectory("${puppetModulesFolder}/${moduleFolder}/${element.path}", 0755, Directive.NONE, project.puppet_user, project.puppet_user, false)
         } else if('files/pool' == element.path || 'files/volume' == element.path ){
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}",element.file, 0755 , Directive.NONE, project.puppet_user,project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0755 , Directive.NONE, project.puppet_user,project.puppet_user, false)
         } else if (null != visitedFile.getParentFile() && 'bin' == visitedFile.getParentFile().getName()) {
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}", element.file, 0755, Directive.NONE, project.puppet_user, project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0755, Directive.NONE, project.puppet_user, project.puppet_user, false)
         } else {
             def info = new CompCuInfo(element.path)
             if (info.isCompCuJar() && info.isGreaterThan(compCuInfo)) {
                 compCuInfo = info
             }
 
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}", element.file, 0644, Directive.NONE, project.puppet_user, project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0644, Directive.NONE, project.puppet_user, project.puppet_user, false)
         }
     }
 


### PR DESCRIPTION
- Previous commit used wrong arguments for `RpmBuilder.addFile(...)`

- Rev to latest redline 1.2.6

- Use 8.4.0 as default version

- Use `root` as the default ownership account. Puppet module code does
  not need to be modifiable by the puppet user. In addition the puppet
  user has changed from `pe-puppet` to `puppet` in the latest builds
  which was resulting in the modules being installed with root
  ownership anyway.