### PR TITLE
[main] Use root user by default for file ownership

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         PLUGINS_REPO_URL = hasProperty('PLUGINS_REPO_URL') ? PLUGINS_REPO_URL : "${BASE_REPO_URL}/${PLUGINS_REPO}"
         USE_LOCAL_REPO = hasProperty('USE_LOCAL_REPO') ? USE_LOCAL_REPO       : 'false'
         rpm_packageName = env.RPM_PACKAGENAME ? env.RPM_PACKAGENAME : 'Dell-ASM-puppet-module-'
-        puppet_user = env.PUPPET_USER ? env.PUPPET_USER : 'puppet'
+        puppet_user = env.PUPPET_USER ? env.PUPPET_USER : 'root'
         moduleName = env.MODULE_NAME ? env.MODULE_NAME : 'puppetlabs-xinetd'
         moduleFolder = env.MODULE_FOLDER ? env.MODULE_FOLDER : 'xinetd'
         gitFolder = env.GIT_FOLDER ? env.GIT_FOLDER : moduleName


### PR DESCRIPTION
The puppet module files in the rpm do not need to be modifiable by the
puppet user, therefore we should use root ownership by default. This
change was intended to be included in a previous PR but got left out.