### PR TITLE
[main] Remove /var/lib/net-snmp/mib_indexes from eql rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+.gradle/
+*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -189,8 +189,5 @@ def buildModuleRpm(moduleName,moduleVersion,puppetModulesFolder='/etc/puppetlabs
     if (moduleName == 'dell-compellent') {
         rpmBuilder.addDirectory("/opt/Dell/ASM/logs/compellent", 0775, Directive.NONE, project.puppet_user, project.puppet_user, false)
     }
-    if (moduleName == 'dell-equallogic') {
-        rpmBuilder.addDirectory("/var/lib/net-snmp/mib_indexes", 0775, Directive.NONE, project.puppet_user, project.puppet_user, false)
-    }
     println rpmBuilder.build(rpmDestinationDirectory)
 }


### PR DESCRIPTION
In CentOS 7 that directory is owned by the net-snmp-libs package. In
CentOS 6 it is not so this change may cause failures on those
builds. Since the equallogic code isn't currently being used that
shouldn't be a problem.