### PR TITLE
[maint] Fix file permissions in puppet module rpms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,16 +153,16 @@ def buildModuleRpm(moduleName,moduleVersion,puppetModulesFolder='/etc/puppetlabs
         } else if (element.isDirectory()) {
             rpmBuilder.addDirectory("${puppetModulesFolder}/${moduleFolder}/${element.path}", 0755, Directive.NONE, project.puppet_user, project.puppet_user, false)
         } else if('files/pool' == element.path || 'files/volume' == element.path ){
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0755 , Directive.NONE, project.puppet_user,project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, 0755, -1, Directive.NONE, project.puppet_user,project.puppet_user, false)
         } else if (null != visitedFile.getParentFile() && 'bin' == visitedFile.getParentFile().getName()) {
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0755, Directive.NONE, project.puppet_user, project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, 0755, -1, Directive.NONE, project.puppet_user, project.puppet_user, false)
         } else {
             def info = new CompCuInfo(element.path)
             if (info.isCompCuJar() && info.isGreaterThan(compCuInfo)) {
                 compCuInfo = info
             }
 
-            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, -1, 0644, Directive.NONE, project.puppet_user, project.puppet_user, false)
+            rpmBuilder.addFile("${puppetModulesFolder}/${moduleFolder}/${element.path}".toString(), element.file, 0644, -1, Directive.NONE, project.puppet_user, project.puppet_user, false)
         }
     }
 


### PR DESCRIPTION
Previous change to specify `addParents` argument to `addFile` got the
order of `dirMode` and `mode` reversed, resulting in incorrect file
permissions.